### PR TITLE
Factorize code for tests.

### DIFF
--- a/common.hh
+++ b/common.hh
@@ -95,6 +95,59 @@ typedef constraints2_t constraints_t;
 typedef ::roboptim::Solver<COST_FUNCTION_TYPE<functionType_t>, constraints_t >
 solver_t;
 
+// See: http://stackoverflow.com/a/20050381/1043187
+#define BOOST_CHECK_SMALL_OR_CLOSE(expected, observed, tol)	\
+  if (std::fabs (expected) < 1e-6) {				\
+    BOOST_CHECK_SMALL(observed, 1e-6);				\
+  } else {							\
+    BOOST_CHECK_CLOSE(expected, observed, tol);			\
+  }
+
+#define CHECK_RESULT(RESULT_TYPE)					\
+  /* Get the result. */							\
+  RESULT_TYPE& result = boost::get<RESULT_TYPE> (res);			\
+  /* Check final x. */							\
+  for (F<functionType_t>::size_type i = 0; i < result.x.size (); ++i)	\
+    BOOST_CHECK_SMALL_OR_CLOSE (result.x[i], ExpectedResult::x[i], x_tol); \
+  /* Check final value. */						\
+  BOOST_CHECK_SMALL_OR_CLOSE (result.value[0], ExpectedResult::fx, f_tol); \
+  /* Display the result. */						\
+  std::cout << "A solution has been found: " << std::endl		\
+  << result << std::endl;
+
+#define PROCESS_RESULT()						\
+  /* Process the result */						\
+  switch (res.which ())							\
+    {									\
+    case solver_t::SOLVER_VALUE:					\
+      {									\
+	CHECK_RESULT (Result);						\
+	break;								\
+      }									\
+    case solver_t::SOLVER_VALUE_WARNINGS:				\
+      {									\
+	CHECK_RESULT (ResultWithWarnings);				\
+	break;								\
+      }									\
+    case solver_t::SOLVER_NO_SOLUTION:					\
+      {									\
+	std::cout << "A solution should have been found. Failing..."	\
+		  << std::endl						\
+		  << "No solution was found."				\
+		  << std::endl;						\
+	BOOST_CHECK_EQUAL (res.which (), solver_t::SOLVER_VALUE);	\
+	return;								\
+      }									\
+    case solver_t::SOLVER_ERROR:					\
+      {									\
+	std::cout << "A solution should have been found. Failing..."	\
+		  << std::endl						\
+		  << boost::get<SolverError> (res).what ()		\
+		  << std::endl;						\
+	BOOST_CHECK_EQUAL (res.which (), solver_t::SOLVER_VALUE);	\
+	return;								\
+      }									\
+    }
 
 struct TestSuiteConfiguration
 {

--- a/roboptim/distance-to-sphere.cc
+++ b/roboptim/distance-to-sphere.cc
@@ -152,8 +152,10 @@ BOOST_AUTO_TEST_CASE (distanceToSphere_problem1)
   using namespace roboptim;
   using namespace roboptim::distanceToSphere;
 
-  // Check tolerance
-  double check_tol = 1e-2;
+  // Tolerances for Boost checks.
+  double f0_tol = 1e-6;
+  double x_tol = 1e-5;
+  double f_tol = 1e-4;
 
   // Build problem.
   boost::shared_ptr <F<functionType_t> > f (new F<functionType_t> ());
@@ -172,7 +174,7 @@ BOOST_AUTO_TEST_CASE (distanceToSphere_problem1)
   // Bounds on phi \in [-Pi, Pi]
   problem.argumentBounds ()[1] = Function::makeInterval (-M_PI, M_PI);
 
-  BOOST_CHECK_CLOSE (soq (x)[0], ExpectedResult::fx0, 1e-6);
+  BOOST_CHECK_SMALL_OR_CLOSE (soq (x)[0], ExpectedResult::fx0, f0_tol);
 
   // Initialize solver.
   SolverFactory<solver_t> factory (SOLVER_NAME, problem);
@@ -192,59 +194,7 @@ BOOST_AUTO_TEST_CASE (distanceToSphere_problem1)
   std::cout << solver << std::endl;
 
   // Process the result
-  switch (res.which ())
-    {
-    case solver_t::SOLVER_VALUE:
-      {
-	// Get the result.
-	Result& result = boost::get<Result> (res);
-
-	// Check final x.
-        for (F<functionType_t>::size_type i = 0; i < result.x.size (); ++i)
-	  BOOST_CHECK_CLOSE (result.x[i], ExpectedResult::x[i], check_tol);
-
-	// Check final value.
-	BOOST_CHECK_CLOSE (result.value[0], ExpectedResult::fx, check_tol);
-
-	// Display the result.
-	std::cout << "A solution has been found: " << std::endl
-		  << result << std::endl;
-
-	break;
-      }
-
-    case solver_t::SOLVER_VALUE_WARNINGS:
-      {
-	// Get the result.
-	ResultWithWarnings& result = boost::get<ResultWithWarnings> (res);
-
-	// Check final x.
-        for (F<functionType_t>::size_type i = 0; i < result.x.size (); ++i)
-	  BOOST_CHECK_CLOSE (result.x[i], ExpectedResult::x[i], check_tol);
-
-	// Check final value.
-	BOOST_CHECK_CLOSE (result.value[0], ExpectedResult::fx, check_tol);
-
-
-	// Display the result.
-	std::cout << "A solution has been found: " << std::endl
-		  << result << std::endl;
-
-	break;
-      }
-
-    case solver_t::SOLVER_NO_SOLUTION:
-    case solver_t::SOLVER_ERROR:
-      {
-	std::cout << "A solution should have been found. Failing..."
-		  << std::endl
-		  << boost::get<SolverError> (res).what ()
-		  << std::endl;
-	BOOST_CHECK_EQUAL (res.which (), solver_t::SOLVER_VALUE);
-
-	return;
-      }
-    }
+  PROCESS_RESULT();
 }
 
 BOOST_AUTO_TEST_SUITE_END ()

--- a/schittkowski/problem_1.cc
+++ b/schittkowski/problem_1.cc
@@ -93,6 +93,11 @@ BOOST_AUTO_TEST_CASE (schittkowski_problem1)
   using namespace roboptim;
   using namespace roboptim::schittkowski::problem1;
 
+  // Tolerances for Boost checks.
+  double f0_tol = 1e-6;
+  double x_tol = 1e-5;
+  double f_tol = 1e-5;
+
   // Build problem.
   F<functionType_t> f;
   solver_t::problem_t problem (f);
@@ -103,7 +108,7 @@ BOOST_AUTO_TEST_CASE (schittkowski_problem1)
   x << -2., 1.;
   problem.startingPoint () = x;
 
-  BOOST_CHECK_CLOSE (f (x)[0], ExpectedResult::f0, 1e-6);
+  BOOST_CHECK_SMALL_OR_CLOSE (f (x)[0], ExpectedResult::f0, f0_tol);
 
   std::cout << f.inputSize () << std::endl;
   std::cout << problem.function ().inputSize () << std::endl;
@@ -128,35 +133,11 @@ BOOST_AUTO_TEST_CASE (schittkowski_problem1)
   std::cout << f.inputSize () << std::endl;
   std::cout << problem.function ().inputSize () << std::endl;
 
-
   // Display solver information.
   std::cout << solver << std::endl;
 
-  // Check if the minimization has succeed.
-  if (res.which () != solver_t::SOLVER_VALUE)
-    {
-      std::cout << "A solution should have been found. Failing..."
-                << std::endl
-                << boost::get<SolverError> (res).what ()
-                << std::endl;
-      BOOST_CHECK_EQUAL (res.which (), solver_t::SOLVER_VALUE);
-      return;
-    }
-
-  // Get the result.
-  Result& result = boost::get<Result> (res);
-
-  // Check final x.
-  for (F<functionType_t>::vector_t::Index i = 0; i < result.x.size (); ++i)
-    BOOST_CHECK_CLOSE (result.x[i], ExpectedResult::x[i], 1e-5);
-
-  // Check final value.
-  BOOST_CHECK_CLOSE (1. + result.value[0], 1. + ExpectedResult::fx, 1e-5);
-
-
-  // Display the result.
-  std::cout << "A solution has been found: " << std::endl
-	    << result << std::endl;
+  // Process the result
+  PROCESS_RESULT();
 }
 
 BOOST_AUTO_TEST_SUITE_END ()

--- a/schittkowski/problem_2.cc
+++ b/schittkowski/problem_2.cc
@@ -97,6 +97,11 @@ BOOST_AUTO_TEST_CASE (schittkowski_problem2)
   using namespace roboptim;
   using namespace roboptim::schittkowski::problem2;
 
+  // Tolerances for Boost checks.
+  double f0_tol = 1e-6;
+  double x_tol = 1e-5;
+  double f_tol = 1e-4;
+
   // Build problem.
   F<functionType_t> f;
   solver_t::problem_t problem (f);
@@ -108,7 +113,7 @@ BOOST_AUTO_TEST_CASE (schittkowski_problem2)
   x << -2., 1.;
   problem.startingPoint () = x;
 
-  BOOST_CHECK_CLOSE (f (x)[0], ExpectedResult::f0, 1e-6);
+  BOOST_CHECK_SMALL_OR_CLOSE (f (x)[0], ExpectedResult::f0, f0_tol);
 
   std::cout << f.inputSize () << std::endl;
   std::cout << problem.function ().inputSize () << std::endl;
@@ -132,35 +137,11 @@ BOOST_AUTO_TEST_CASE (schittkowski_problem2)
   std::cout << f.inputSize () << std::endl;
   std::cout << problem.function ().inputSize () << std::endl;
 
-
   // Display solver information.
   std::cout << solver << std::endl;
 
-  // Check if the minimization has succeed.
-  if (res.which () != solver_t::SOLVER_VALUE)
-    {
-      std::cout << "A solution should have been found. Failing..."
-                << std::endl
-                << boost::get<SolverError> (res).what ()
-                << std::endl;
-      BOOST_CHECK_EQUAL (res.which (), solver_t::SOLVER_VALUE);
-      return;
-    }
-
-  // Get the result.
-  Result& result = boost::get<Result> (res);
-
-  // Check final x.
-  for (F<functionType_t>::vector_t::Index i = 0; i < result.x.size (); ++i)
-    BOOST_CHECK_CLOSE (result.x[i], ExpectedResult::x[i], 1e-5);
-
-  // Check final value.
-  BOOST_CHECK_CLOSE (1. + result.value[0], 1. + ExpectedResult::fx, 1e-4);
-
-
-  // Display the result.
-  std::cout << "A solution has been found: " << std::endl
-	    << result << std::endl;
+  // Process the result
+  PROCESS_RESULT();
 }
 
 BOOST_AUTO_TEST_SUITE_END ()

--- a/schittkowski/problem_3.cc
+++ b/schittkowski/problem_3.cc
@@ -91,6 +91,11 @@ BOOST_AUTO_TEST_CASE (schittkowski_problem3)
   using namespace roboptim;
   using namespace roboptim::schittkowski::problem3;
 
+  // Tolerances for Boost checks.
+  double f0_tol = 1e-6;
+  double x_tol = 1e-5;
+  double f_tol = 1e-4;
+
   // Build problem.
   F<functionType_t> f;
   solver_t::problem_t problem (f);
@@ -101,7 +106,7 @@ BOOST_AUTO_TEST_CASE (schittkowski_problem3)
   x << 10., 1.;
   problem.startingPoint () = x;
 
-  BOOST_CHECK_CLOSE (f (x)[0], ExpectedResult::f0, 1e-6);
+  BOOST_CHECK_SMALL_OR_CLOSE (f (x)[0], ExpectedResult::f0, f0_tol);
 
   std::cout << f.inputSize () << std::endl;
   std::cout << problem.function ().inputSize () << std::endl;
@@ -125,35 +130,11 @@ BOOST_AUTO_TEST_CASE (schittkowski_problem3)
   std::cout << f.inputSize () << std::endl;
   std::cout << problem.function ().inputSize () << std::endl;
 
-
   // Display solver information.
   std::cout << solver << std::endl;
 
-  // Check if the minimization has succeed.
-  if (res.which () != solver_t::SOLVER_VALUE)
-    {
-      std::cout << "A solution should have been found. Failing..."
-                << std::endl
-                << boost::get<SolverError> (res).what ()
-                << std::endl;
-      BOOST_CHECK_EQUAL (res.which (), solver_t::SOLVER_VALUE);
-      return;
-    }
-
-  // Get the result.
-  Result& result = boost::get<Result> (res);
-
-  // Check final x.
-  for (F<functionType_t>::vector_t::Index i = 0; i < result.x.size (); ++i)
-    BOOST_CHECK_CLOSE (1. + result.x[i], 1. + ExpectedResult::x[i], 1e-3);
-
-  // Check final value.
-  BOOST_CHECK_CLOSE (1. + result.value[0], 1. + ExpectedResult::fx, 1e-6);
-
-
-  // Display the result.
-  std::cout << "A solution has been found: " << std::endl
-	    << result << std::endl;
+  // Process the result
+  PROCESS_RESULT();
 }
 
 BOOST_AUTO_TEST_SUITE_END ()

--- a/schittkowski/problem_4.cc
+++ b/schittkowski/problem_4.cc
@@ -91,6 +91,11 @@ BOOST_AUTO_TEST_CASE (schittkowski_problem4)
   using namespace roboptim;
   using namespace roboptim::schittkowski::problem4;
 
+  // Tolerances for Boost checks.
+  double f0_tol = 1e-4;
+  double x_tol = 1e-4;
+  double f_tol = 1e-4;
+
   // Build problem.
   F<functionType_t> f;
   solver_t::problem_t problem (f);
@@ -102,7 +107,7 @@ BOOST_AUTO_TEST_CASE (schittkowski_problem4)
   x << 1.125, 0.125;
   problem.startingPoint () = x;
 
-  BOOST_CHECK_CLOSE (f (x)[0], ExpectedResult::f0, 1e-4);
+  BOOST_CHECK_CLOSE (f (x)[0], ExpectedResult::f0, f0_tol);
 
   std::cout << f.inputSize () << std::endl;
   std::cout << problem.function ().inputSize () << std::endl;
@@ -126,35 +131,11 @@ BOOST_AUTO_TEST_CASE (schittkowski_problem4)
   std::cout << f.inputSize () << std::endl;
   std::cout << problem.function ().inputSize () << std::endl;
 
-
   // Display solver information.
   std::cout << solver << std::endl;
 
-  // Check if the minimization has succeed.
-  if (res.which () != solver_t::SOLVER_VALUE)
-    {
-      std::cout << "A solution should have been found. Failing..."
-                << std::endl
-                << boost::get<SolverError> (res).what ()
-                << std::endl;
-      BOOST_CHECK_EQUAL (res.which (), solver_t::SOLVER_VALUE);
-      return;
-    }
-
-  // Get the result.
-  Result& result = boost::get<Result> (res);
-
-  // Check final x.
-  for (F<functionType_t>::vector_t::Index i = 0; i < result.x.size (); ++i)
-    BOOST_CHECK_CLOSE (1. + result.x[i], 1. + ExpectedResult::x[i], 1e-4);
-
-  // Check final value.
-  BOOST_CHECK_CLOSE (1. + result.value[0], 1. + ExpectedResult::fx, 1e-4);
-
-
-  // Display the result.
-  std::cout << "A solution has been found: " << std::endl
-	    << result << std::endl;
+  // Process the result
+  PROCESS_RESULT();
 }
 
 BOOST_AUTO_TEST_SUITE_END ()

--- a/schittkowski/problem_5.cc
+++ b/schittkowski/problem_5.cc
@@ -92,6 +92,11 @@ BOOST_AUTO_TEST_CASE (schittkowski_problem5)
   using namespace roboptim;
   using namespace roboptim::schittkowski::problem5;
 
+  // Tolerances for Boost checks.
+  double f0_tol = 1e-4;
+  double x_tol = 1e-4;
+  double f_tol = 1e-4;
+
   // Build problem.
   F<functionType_t> f;
   solver_t::problem_t problem (f);
@@ -103,7 +108,7 @@ BOOST_AUTO_TEST_CASE (schittkowski_problem5)
   x << 0., 0.;
   problem.startingPoint () = x;
 
-  BOOST_CHECK_CLOSE (f (x)[0], ExpectedResult::f0, 1e-4);
+  BOOST_CHECK_SMALL_OR_CLOSE (f (x)[0], ExpectedResult::f0, f0_tol);
 
   std::cout << f.inputSize () << std::endl;
   std::cout << problem.function ().inputSize () << std::endl;
@@ -127,35 +132,11 @@ BOOST_AUTO_TEST_CASE (schittkowski_problem5)
   std::cout << f.inputSize () << std::endl;
   std::cout << problem.function ().inputSize () << std::endl;
 
-
   // Display solver information.
   std::cout << solver << std::endl;
 
-  // Check if the minimization has succeed.
-  if (res.which () != solver_t::SOLVER_VALUE)
-    {
-      std::cout << "A solution should have been found. Failing..."
-                << std::endl
-                << boost::get<SolverError> (res).what ()
-                << std::endl;
-      BOOST_CHECK_EQUAL (res.which (), solver_t::SOLVER_VALUE);
-      return;
-    }
-
-  // Get the result.
-  Result& result = boost::get<Result> (res);
-
-  // Check final x.
-  for (F<functionType_t>::vector_t::Index i = 0; i < result.x.size (); ++i)
-    BOOST_CHECK_CLOSE (1. + result.x[i], 1. + ExpectedResult::x[i], 1e-4);
-
-  // Check final value.
-  BOOST_CHECK_CLOSE (1. + result.value[0], 1. + ExpectedResult::fx, 1e-4);
-
-
-  // Display the result.
-  std::cout << "A solution has been found: " << std::endl
-	    << result << std::endl;
+  // Process the result
+  PROCESS_RESULT();
 }
 
 BOOST_AUTO_TEST_SUITE_END ()

--- a/schittkowski/problem_6.cc
+++ b/schittkowski/problem_6.cc
@@ -139,6 +139,11 @@ BOOST_AUTO_TEST_CASE (schittkowski_problem4)
   using namespace roboptim;
   using namespace roboptim::schittkowski::problem6;
 
+  // Tolerances for Boost checks.
+  double f0_tol = 1e-4;
+  double x_tol = 1e-4;
+  double f_tol = 1e-4;
+
   // Build problem.
   F<functionType_t> f;
   solver_t::problem_t problem (f);
@@ -151,7 +156,7 @@ BOOST_AUTO_TEST_CASE (schittkowski_problem4)
   x << -1.2, 1.;
   problem.startingPoint () = x;
 
-  BOOST_CHECK_CLOSE (f (x)[0], ExpectedResult::f0, 1e-4);
+  BOOST_CHECK_SMALL_OR_CLOSE (f (x)[0], ExpectedResult::f0, f0_tol);
 
   std::cout << f.inputSize () << std::endl;
   std::cout << problem.function ().inputSize () << std::endl;
@@ -175,35 +180,11 @@ BOOST_AUTO_TEST_CASE (schittkowski_problem4)
   std::cout << f.inputSize () << std::endl;
   std::cout << problem.function ().inputSize () << std::endl;
 
-
   // Display solver information.
   std::cout << solver << std::endl;
 
-  // Check if the minimization has succeed.
-  if (res.which () != solver_t::SOLVER_VALUE)
-    {
-      std::cout << "A solution should have been found. Failing..."
-                << std::endl
-                << boost::get<SolverError> (res).what ()
-                << std::endl;
-      BOOST_CHECK_EQUAL (res.which (), solver_t::SOLVER_VALUE);
-      return;
-    }
-
-  // Get the result.
-  Result& result = boost::get<Result> (res);
-
-  // Check final x.
-  for (F<functionType_t>::vector_t::Index i = 0; i < result.x.size (); ++i)
-    BOOST_CHECK_CLOSE (1. + result.x[i], 1. + ExpectedResult::x[i], 1e-4);
-
-  // Check final value.
-  BOOST_CHECK_CLOSE (1. + result.value[0], 1. + ExpectedResult::fx, 1e-4);
-
-
-  // Display the result.
-  std::cout << "A solution has been found: " << std::endl
-	    << result << std::endl;
+  // Process the result
+  PROCESS_RESULT();
 }
 
 BOOST_AUTO_TEST_SUITE_END ()

--- a/schittkowski/problem_71.cc
+++ b/schittkowski/problem_71.cc
@@ -342,6 +342,11 @@ BOOST_AUTO_TEST_CASE (problem_71)
   using namespace roboptim;
   using namespace roboptim::schittkowski::problem71;
 
+  // Tolerances for Boost checks.
+  double f0_tol = 1e-6;
+  double x_tol = 1e-3;
+  double f_tol = 1e-3;
+
   // Build problem.
   F<functionType_t> f;
   solver_t::problem_t problem (f);
@@ -370,7 +375,7 @@ BOOST_AUTO_TEST_CASE (problem_71)
   x << 1., 5., 5., 1.;
   problem.startingPoint () = x;
 
-  BOOST_CHECK_CLOSE (f (x)[0], ExpectedResult::f0, 1e-6);
+  BOOST_CHECK_SMALL_OR_CLOSE (f (x)[0], ExpectedResult::f0, f0_tol);
 
   // Initialize solver.
   SolverFactory<solver_t> factory (SOLVER_NAME, problem);
@@ -378,7 +383,6 @@ BOOST_AUTO_TEST_CASE (problem_71)
   OptimizationLogger<solver_t> logger
     (solver,
      "/tmp/roboptim-shared-tests/" SOLVER_NAME "/schittkowski/problem-71");
-
 
   // Set optional log file for debugging
   SET_LOG_FILE(solver);
@@ -389,30 +393,8 @@ BOOST_AUTO_TEST_CASE (problem_71)
   // Display solver information.
   std::cout << solver << std::endl;
 
-  // Check if the minimization has succeed.
-  if (res.which () != solver_t::SOLVER_VALUE)
-    {
-      std::cout << "A solution should have been found. Failing..."
-                << std::endl
-                << boost::get<SolverError> (res).what ()
-                << std::endl;
-      BOOST_CHECK_EQUAL (res.which (), solver_t::SOLVER_VALUE);
-      return;
-    }
-
-  // Get the result.
-  Result& result = boost::get<Result> (res);
-
-  // Check final x.
-  for (F<functionType_t>::vector_t::Index i = 0; i < result.x.size (); ++i)
-    BOOST_CHECK_CLOSE (result.x[i], ExpectedResult::x[i], 1e-3);
-
-  // Check final value.
-  BOOST_CHECK_CLOSE (1. + result.value[0], 1. + ExpectedResult::fx, 1e-3);
-
-  // Display the result.
-  std::cout << "A solution has been found: " << std::endl
-  	    << result << std::endl;
+  // Process the result
+  PROCESS_RESULT();
 }
 
 BOOST_AUTO_TEST_SUITE_END ()

--- a/schittkowski/problem_71b.cc
+++ b/schittkowski/problem_71b.cc
@@ -291,6 +291,11 @@ BOOST_AUTO_TEST_CASE (problem_71b)
   using namespace roboptim;
   using namespace roboptim::schittkowski::problem71b;
 
+  // Tolerances for Boost checks.
+  double f0_tol = 1e-6;
+  double x_tol = 1e-3;
+  double f_tol = 1e-3;
+
   // Build problem.
   F<functionType_t> f;
   solver_t::problem_t problem (f);
@@ -314,7 +319,7 @@ BOOST_AUTO_TEST_CASE (problem_71b)
 
   problem.addConstraint
     (boost::static_pointer_cast<
-      GenericDifferentiableFunction<functionType_t>  > (g),
+     GenericDifferentiableFunction<functionType_t>  > (g),
      bounds, scales);
 
   // Set the starting point.
@@ -322,7 +327,7 @@ BOOST_AUTO_TEST_CASE (problem_71b)
   x << 1., 5., 5., 1.;
   problem.startingPoint () = x;
 
-  BOOST_CHECK_CLOSE (f (x)[0], ExpectedResult::f0, 1e-6);
+  BOOST_CHECK_SMALL_OR_CLOSE (f (x)[0], ExpectedResult::f0, f0_tol);
 
   // Initialize solver.
   SolverFactory<solver_t> factory (SOLVER_NAME, problem);
@@ -340,30 +345,8 @@ BOOST_AUTO_TEST_CASE (problem_71b)
   // Display solver information.
   std::cout << solver << std::endl;
 
-  // Check if the minimization has succeed.
-  if (res.which () != solver_t::SOLVER_VALUE)
-    {
-      std::cout << "A solution should have been found. Failing..."
-                << std::endl
-                << boost::get<SolverError> (res).what ()
-                << std::endl;
-      BOOST_CHECK_EQUAL (res.which (), solver_t::SOLVER_VALUE);
-      return;
-    }
-
-  // Get the result.
-  Result& result = boost::get<Result> (res);
-
-  // Check final x.
-  for (F<functionType_t>::vector_t::Index i = 0; i < result.x.size (); ++i)
-    BOOST_CHECK_CLOSE (result.x[i], ExpectedResult::x[i], 1e-3);
-
-  // Check final value.
-  BOOST_CHECK_CLOSE (1. + result.value[0], 1. + ExpectedResult::fx, 1e-3);
-
-  // Display the result.
-  std::cout << "A solution has been found: " << std::endl
-  	    << result << std::endl;
+  // Process the result
+  PROCESS_RESULT();
 }
 
 BOOST_AUTO_TEST_SUITE_END ()


### PR DESCRIPTION
cc @thomas-moulard 

Several solvers (e.g. NLopt) can find the expected solution while giving a warning (e.g. the reason why the solver stopped). I thought that since all that matters is the result, I added support for `SOLVER_VALUE_WARNINGS` and factorized things a bit. Tolerances for `f0`, `x` and `f` have to be set at the beginning of the test function.

I also added `BOOST_CHECK_SMALL_OR_CLOSE` because I had a test failing when the solver returned `1e-26` and `0.` was expected. I based it on [this SO question](http://stackoverflow.com/questions/1093453/difference-between-boost-check-close-and-boost-check-close-fraction), but it is certainly improvable.
